### PR TITLE
Ignore transpile spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha --compilers js:babel-core/register --bail src/**/*.spec.js",
     "prepublish": "npm run clean && npm run build",
     "clean": "rm -rf dist",
-    "build": "babel -q -L -D ./src/ --out-dir ./dist/"
+    "build": "babel -q -L -D ./src/ --out-dir ./dist/ --ignore ./src/*.spec.js"
   },
   "keywords": [
     "bookshelf",


### PR DESCRIPTION
Why:
To ignore all spec files when transpiling with babel

This change addresses the need by:
Adding `--ignore` in the build script
